### PR TITLE
Update libfdt and support current ndless-sdk versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
+*.zehn
 *.elf
 *.tns

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,6 @@ BUILDFLAGS := -DBUILD_DATE="\"$(shell date --rfc-2822)\""
 BUILDFLAGS += -DGIT_COMMIT="\"$(shell git rev-parse --short HEAD)\""
 
 LDFLAGS = -lnspireio
-OBJCOPY := "$(shell which arm-elf-objcopy 2>/dev/null)"
-ifeq (${OBJCOPY},"")
-	OBJCOPY := arm-none-eabi-objcopy
-endif
 EXE = linuxloader2.tns
 
 OBJS  = $(patsubst %.c,%.o,$(wildcard *.c))
@@ -30,7 +26,8 @@ all: $(EXE)
 
 $(EXE): $(OBJS)
 	$(LD) $^ -o $(@:.tns=.elf) $(LDFLAGS)
-	$(OBJCOPY) -O binary $(@:.tns=.elf) $@
+	genzehn --input $(@:.tns=.elf) --output $(@:.tns=.zehn) --name "Linux Loader v2" --version 1 --author "tangrs"
+	make-prg $(@:.tns=.zehn) $@
 
 clean:
 	rm -f $(OBJS) *.elf

--- a/common.c
+++ b/common.c
@@ -48,7 +48,7 @@ void setget_phys(char *arg) {
         settings.phys.start = (void*)start;
         settings.phys.size  = size;
     }
-    printl("Physical memory range is 0x%p-0x%p" NEWLINE, settings.phys.start, (void*)((char*)settings.phys.start + settings.phys.size));
+    printl("Physical memory range is %p-%p" NEWLINE, settings.phys.start, (void*)((char*)settings.phys.start + settings.phys.size));
 }
 
 void setget_rdisksize(char *arg) {

--- a/common.h
+++ b/common.h
@@ -18,8 +18,9 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include <stdarg.h>
 #include <stddef.h>
-#include <nspireio.h>
+#include <nspireio/nspireio.h>
 
 #define PAGE_SIZE 0x1000
 #define DTB_MACH_ID 3503

--- a/libfdt/fdt.c
+++ b/libfdt/fdt.c
@@ -79,7 +79,7 @@ const void *fdt_offset_ptr(const void *fdt, int offset, unsigned int len)
 	const char *p;
 
 	if (fdt_version(fdt) >= 0x11)
-		if (((int)(offset + len) < offset)
+		if (((offset + len) < offset)
 		    || ((offset + len) > fdt_size_dt_struct(fdt)))
 			return NULL;
 
@@ -214,7 +214,7 @@ int fdt_move(const void *fdt, void *buf, int bufsize)
 {
 	FDT_CHECK_HEADER(fdt);
 
-	if ((int)fdt_totalsize(fdt) > bufsize)
+	if (fdt_totalsize(fdt) > bufsize)
 		return -FDT_ERR_NOSPACE;
 
 	memmove(buf, fdt, fdt_totalsize(fdt));

--- a/libfdt/fdt_empty_tree.c
+++ b/libfdt/fdt_empty_tree.c
@@ -81,4 +81,3 @@ int fdt_create_empty_tree(void *buf, int bufsize)
 
 	return fdt_open_into(buf, buf, bufsize);
 }
-

--- a/libfdt/fdt_ro.c
+++ b/libfdt/fdt_ro.c
@@ -494,7 +494,7 @@ int fdt_node_offset_by_phandle(const void *fdt, uint32_t phandle)
 {
 	int offset;
 
-	if ((phandle == 0) || (phandle == (uint32_t)-1))
+	if ((phandle == 0) || (phandle == -1))
 		return -FDT_ERR_BADPHANDLE;
 
 	FDT_CHECK_HEADER(fdt);

--- a/libfdt/fdt_strerror.c
+++ b/libfdt/fdt_strerror.c
@@ -85,7 +85,7 @@ const char *fdt_strerror(int errval)
 		return "<valid offset/length>";
 	else if (errval == 0)
 		return "<no error>";
-	else if (errval > (int)-FDT_ERRTABSIZE) {
+	else if (errval > -FDT_ERRTABSIZE) {
 		const char *s = fdt_errtable[-errval].str;
 
 		if (s)

--- a/libfdt/fdt_sw.c
+++ b/libfdt/fdt_sw.c
@@ -78,7 +78,7 @@ static void *_fdt_grab_space(void *fdt, size_t len)
 	spaceleft = fdt_totalsize(fdt) - fdt_off_dt_struct(fdt)
 		- fdt_size_dt_strings(fdt);
 
-	if (((int)(offset + len) < offset) || ((int)(offset + len) > spaceleft))
+	if ((offset + len < offset) || (offset + len > spaceleft))
 		return NULL;
 
 	fdt_set_size_dt_struct(fdt, offset + len);
@@ -89,7 +89,7 @@ int fdt_create(void *buf, int bufsize)
 {
 	void *fdt = buf;
 
-	if (bufsize < (int)sizeof(struct fdt_header))
+	if (bufsize < sizeof(struct fdt_header))
 		return -FDT_ERR_NOSPACE;
 
 	memset(buf, 0, bufsize);
@@ -180,7 +180,7 @@ static int _fdt_find_add_string(void *fdt, const char *s)
 	/* Add it */
 	offset = -strtabsize - len;
 	struct_top = fdt_off_dt_struct(fdt) + fdt_size_dt_struct(fdt);
-	if ((int)fdt_totalsize(fdt) + offset < struct_top)
+	if (fdt_totalsize(fdt) + offset < struct_top)
 		return 0; /* no more room :( */
 
 	memcpy(strtab + offset, s, len);

--- a/libfdt/libfdt_env.h
+++ b/libfdt/libfdt_env.h
@@ -1,10 +1,9 @@
 #ifndef _LIBFDT_ENV_H
 #define _LIBFDT_ENV_H
 
-//#include <stddef.h>
-//#include <stdint.h>
-//#include <string.h>
-#include <os.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 #define EXTRACT_BYTE(n)	((unsigned long long)((uint8_t *)&x)[n])
 static inline uint16_t fdt16_to_cpu(uint16_t x)
@@ -26,8 +25,5 @@ static inline uint64_t fdt64_to_cpu(uint64_t x)
 }
 #define cpu_to_fdt64(x) fdt64_to_cpu(x)
 #undef EXTRACT_BYTE
-
-/* Included here because os.h doesn't include it for some reason */
-const void* memchr(const void *ptr, int value, size_t num);
 
 #endif /* _LIBFDT_ENV_H */

--- a/main.c
+++ b/main.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
     if (detect_memory())
         printl("Warning: Could not detect amount of memory!" NEWLINE);
     else
-        printl("Physical memory at: 0x%p-0x%p" NEWLINE,
+        printl("Physical memory at: %p-%p" NEWLINE,
             settings.phys.start, (void*)((char*)settings.phys.start + settings.phys.size));
 
     if (detect_serialnr())

--- a/main.c
+++ b/main.c
@@ -17,7 +17,6 @@
 */
 
 #include <os.h>
-#include <nspireio.h>
 #include "common.h"
 #include "memory.h"
 #include "cmd.h"
@@ -74,7 +73,7 @@ int main(int argc, char *argv[]) {
     while (1) {
         char cmd[128];
         nio_puts("> ");
-        if (nio_gets(cmd)) {
+        if (nio_getsn(cmd, 127)) {
             if (process_cmd(cmd)) break;
         }
     }


### PR DESCRIPTION
Just copied the current libfdt from the linux kernel tree and fixed build errors.
Seems to work fine.
